### PR TITLE
Add Option prism

### DIFF
--- a/src/Aether/Aether.fs
+++ b/src/Aether/Aether.fs
@@ -179,6 +179,14 @@ module Optics =
             Map.toList, Map.ofList
 
     [<RequireQualifiedAccess>]
+    module Option =
+
+        /// Prism to the value in an Option
+        let value_ : Prism<'v option, 'v> =
+            (id,
+             (fun v -> function | Some _ -> Some v | None -> None))
+
+    [<RequireQualifiedAccess>]
     module Choice =
 
         /// Prism to Choice1Of2

--- a/tests/Aether.Tests/Aether.Tests.fs
+++ b/tests/Aether.Tests/Aether.Tests.fs
@@ -40,6 +40,10 @@ module ``Built-in Prisms`` =
         Prism.followsPrismLaws Choice.choice2Of2_ outer inner dummy f
 
     [<Property>]
+    let ``Option.value_ follows the Prism Laws`` (outer : obj option) inner dummy f =
+        Prism.followsPrismLaws Option.value_ outer inner dummy f
+
+    [<Property>]
     let ``head_ follows the Prism Laws`` (outer : obj list) inner dummy f =
         Prism.followsPrismLaws List.head_ outer inner dummy f
 


### PR DESCRIPTION
As discussed on Slack. This was just missing, and while it appears to have no use at first, it actually can be very useful in a larger composed optic where the option's value happens to be a complex type, or when looking to perform a mapping of an option through a composed optic.

Test added.