### PR TITLE
Dotnetcore support for Aether

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ FakesAssemblies/
 
 # FSharp Lint
 *.FSharpLint
+
+**/project.lock.json

--- a/src/Aether/project.json
+++ b/src/Aether/project.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "compilerName": "fsc",
+    "compile": {
+      "includeFiles": [
+        "Aether.fs"
+      ]
+    }
+  },
+  "dependencies": {
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
+    "NETStandard.Library": "1.5.0-rc2-24027"
+  },
+  "tools": {
+    "dotnet-compile-fsc": {
+      "version": "1.0.0-preview1-*",
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win81",
+        "netstandard1.3"
+      ]
+    }
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "imports": [
+        "portable-net45+win8",
+        "dnxcore50"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR shows the dotnet core project representation of Aether.  

There was nothing in this project that was not .Net Standard compatible.

You might find the F# dotnetcore FAQ interesting reading too: https://github.com/dotnet/netcorecli-fsc/wiki/FAQ
