### PR TITLE
Include source files in package for Fable support

### DIFF
--- a/src/Aether/Aether.fsproj
+++ b/src/Aether/Aether.fsproj
@@ -4,6 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="*.fsproj; **\*.fs" PackagePath="fable\" />
     <Compile Include="Aether.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hey there!

The Fable FAQ asks to add the source files to the NuGet package: https://fable.io/faq/#library-authors
Not sure how to test this properly, tbh, but the library itself does work fine if copied into a Fable project.